### PR TITLE
Add GPG signature support to log commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,39 @@ Add this line to .bashrc, .zshrc or something
 ### lg, lgg, lgr
 
 	// git log --stat --pretty=format:'%Cblue%h %Cgreen%ar %Cred%an %Creset%s %Cred%d' | head
+	// Includes GPG signature status: G (signed) or N (unsigned)
 	lg
 
 	// git log --stat --pretty=format:'%Cblue%h %Cgreen%ar %Cred%an %Creset%s %Cred%d'
+	// Includes GPG signature status: G (signed) or N (unsigned)
 	lgg
 
 	// git log --graph --date-order --pretty=format:'%Cblue%h %Cgreen%ci %Cred%an %Cblue%m %Creset%s %Cred%d'
+	// Includes GPG signature status: G (signed) or N (unsigned)
 	lgr
+
+### lga, lgap
+
+	// Show only GPG-signed commits (defaults to staging/main/master..HEAD)
+	lga
+	lga <commit-range>
+
+	// Show GPG-signed commits with patches
+	lgap
+	lgap <commit-range>
+
+### lgu, lgup
+
+	// Show only unsigned commits (defaults to staging/main/master..HEAD)
+	lgu
+	lgu <commit-range>
+
+	// Show unsigned commits with patches
+	lgup
+	lgup <commit-range>
+
+### lgsign
+
+	// Interactively review and GPG-sign unsigned commits using rebase
+	lgsign
+	lgsign <base-branch>

--- a/bin/lg
+++ b/bin/lg
@@ -1,2 +1,2 @@
 #!/bin/sh
-git log --stat --pretty=format:'%Cblue%h %Cgreen%ar %Cred%an %Creset%s %Cred%d' | head
+git -c color.ui=always log --stat --pretty=format:'%Cblue%h %G? %Cgreen%ar %Cred%an %Creset%s %Cred%d' | sed -e $'s/ G / \033[32mG\033[0m /' -e $'s/ N / \033[31mN\033[0m /' | head

--- a/bin/lga
+++ b/bin/lga
@@ -1,0 +1,12 @@
+#!/bin/sh
+if [ $# -eq 0 ]; then
+  if git rev-parse --verify staging >/dev/null 2>&1; then
+    base="staging"
+  elif git rev-parse --verify main >/dev/null 2>&1; then
+    base="main"
+  else
+    base="master"
+  fi
+  set -- "$base..HEAD"
+fi
+git -c color.ui=always log --format='%Cblue%h %G? %Cgreen%ar %Cred%an %Creset%s %Cred%d' "$@" | grep ' G ' | sed $'s/ G / \033[32mG\033[0m /' | less -FRX

--- a/bin/lgap
+++ b/bin/lgap
@@ -1,0 +1,15 @@
+#!/bin/sh
+if [ $# -eq 0 ]; then
+  if git rev-parse --verify staging >/dev/null 2>&1; then
+    base="staging"
+  elif git rev-parse --verify main >/dev/null 2>&1; then
+    base="main"
+  else
+    base="master"
+  fi
+  set -- "$base..HEAD"
+fi
+commits=$(git log --format='%H %G?' "$@" | grep ' G$' | cut -d' ' -f1)
+if [ -n "$commits" ]; then
+  git -c color.ui=always log -p --no-walk=sorted $commits | less -FRX
+fi

--- a/bin/lgg
+++ b/bin/lgg
@@ -1,2 +1,2 @@
 #!/bin/sh
-git log --stat --pretty=format:'%Cblue%h %Cgreen%ar %Cred%an %Creset%s %Cred%d'
+git -c color.ui=always log --stat --pretty=format:'%Cblue%h %G? %Cgreen%ar %Cred%an %Creset%s %Cred%d' | sed -e $'s/ G / \033[32mG\033[0m /' -e $'s/ N / \033[31mN\033[0m /' | less -FRX

--- a/bin/lgr
+++ b/bin/lgr
@@ -1,2 +1,2 @@
 #!/bin/sh
-git log --graph --date-order --pretty=format:'%Cblue%h %Cgreen%ci %Cred%an %Cblue%m %Creset%s %Cred%d'
+git -c color.ui=always log --graph --date-order --pretty=format:'%Cblue%h %G? %Cgreen%ci %Cred%an %Cblue%m %Creset%s %Cred%d' | sed -e $'s/ G / \033[32mG\033[0m /' -e $'s/ N / \033[31mN\033[0m /' | less -FRX

--- a/bin/lgsign
+++ b/bin/lgsign
@@ -1,0 +1,66 @@
+#!/bin/sh
+if [ $# -eq 0 ]; then
+  if git rev-parse --verify staging >/dev/null 2>&1; then
+    base="staging"
+  elif git rev-parse --verify main >/dev/null 2>&1; then
+    base="main"
+  else
+    base="master"
+  fi
+else
+  base="$1"
+fi
+
+range="$base..HEAD"
+commits=$(git log --format='%H %G?' --reverse "$range" | grep ' N$' | cut -d' ' -f1)
+
+if [ -z "$commits" ]; then
+  echo "No unsigned commits in $range"
+  exit 0
+fi
+
+total=$(echo "$commits" | wc -l | tr -d ' ')
+sign_ids=$(mktemp)
+count=0
+sign_count=0
+
+for sha in $commits; do
+  count=$((count + 1))
+  echo ""
+  echo "=== [$count/$total] $(git log -1 --format='%h %s' "$sha") ==="
+  git -c color.ui=always show "$sha" | less -FRX
+  printf "Sign this commit? [y/n/q] "
+  read -r ans < /dev/tty
+  case $ans in
+    y|Y)
+      sign_count=$((sign_count + 1))
+      git log -1 --format='%at %s' "$sha" >> "$sign_ids"
+      ;;
+    q|Q) break ;;
+  esac
+done
+
+if [ "$sign_count" -eq 0 ]; then
+  echo "No commits selected."
+  rm "$sign_ids"
+  exit 0
+fi
+
+echo ""
+echo "$sign_count commit(s) will be signed. Proceed? [y/n]"
+read -r confirm < /dev/tty
+if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+  echo "Aborted."
+  rm "$sign_ids"
+  exit 0
+fi
+
+git rebase --exec "
+  id=\$(git log -1 --format='%at %s')
+  if grep -qF \"\$id\" '$sign_ids'; then
+    git commit --amend --no-edit -S
+  fi
+" "$base"
+
+rm "$sign_ids"
+echo "Done. Run lgu to verify."

--- a/bin/lgsign
+++ b/bin/lgsign
@@ -20,7 +20,7 @@ if [ -z "$commits" ]; then
 fi
 
 total=$(echo "$commits" | wc -l | tr -d ' ')
-sign_ids=$(mktemp)
+sign_shas=""
 count=0
 sign_count=0
 
@@ -34,7 +34,7 @@ for sha in $commits; do
   case $ans in
     y|Y)
       sign_count=$((sign_count + 1))
-      git log -1 --format='%at %s' "$sha" >> "$sign_ids"
+      sign_shas="$sign_shas $sha"
       ;;
     q|Q) break ;;
   esac
@@ -42,7 +42,6 @@ done
 
 if [ "$sign_count" -eq 0 ]; then
   echo "No commits selected."
-  rm "$sign_ids"
   exit 0
 fi
 
@@ -51,11 +50,15 @@ echo "$sign_count commit(s) will be signed. Proceed? [y/n]"
 read -r confirm < /dev/tty
 if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
   echo "Aborted."
-  rm "$sign_ids"
   exit 0
 fi
 
-git rebase --exec "id=\$(git log -1 --format='%at %s'); if grep -qF \"\$id\" '$sign_ids'; then git commit --amend --no-edit -S; fi" "$base"
+sed_script=$(mktemp)
+for sha in $sign_shas; do
+  short=$(git rev-parse --short "$sha")
+  printf '/^pick %s/a\\\nexec git commit --amend --no-edit -S\n' "$short" >> "$sed_script"
+done
 
-rm "$sign_ids"
+GIT_SEQUENCE_EDITOR="sed -i '' -f '$sed_script'" git rebase -i "$base"
+rm "$sed_script"
 echo "Done. Run lgu to verify."

--- a/bin/lgsign
+++ b/bin/lgsign
@@ -55,12 +55,7 @@ if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
   exit 0
 fi
 
-git rebase --exec "
-  id=\$(git log -1 --format='%at %s')
-  if grep -qF \"\$id\" '$sign_ids'; then
-    git commit --amend --no-edit -S
-  fi
-" "$base"
+git rebase --exec "id=\$(git log -1 --format='%at %s'); if grep -qF \"\$id\" '$sign_ids'; then git commit --amend --no-edit -S; fi" "$base"
 
 rm "$sign_ids"
 echo "Done. Run lgu to verify."

--- a/bin/lgu
+++ b/bin/lgu
@@ -1,0 +1,12 @@
+#!/bin/sh
+if [ $# -eq 0 ]; then
+  if git rev-parse --verify staging >/dev/null 2>&1; then
+    base="staging"
+  elif git rev-parse --verify main >/dev/null 2>&1; then
+    base="main"
+  else
+    base="master"
+  fi
+  set -- "$base..HEAD"
+fi
+git -c color.ui=always log --format='%Cblue%h %G? %Cgreen%ar %Cred%an %Creset%s %Cred%d' "$@" | grep ' N ' | sed $'s/ N / \033[31mN\033[0m /' | less -FRX

--- a/bin/lgup
+++ b/bin/lgup
@@ -1,0 +1,15 @@
+#!/bin/sh
+if [ $# -eq 0 ]; then
+  if git rev-parse --verify staging >/dev/null 2>&1; then
+    base="staging"
+  elif git rev-parse --verify main >/dev/null 2>&1; then
+    base="main"
+  else
+    base="master"
+  fi
+  set -- "$base..HEAD"
+fi
+commits=$(git log --format='%H %G?' "$@" | grep ' N$' | cut -d' ' -f1)
+if [ -n "$commits" ]; then
+  git -c color.ui=always log -p --no-walk=sorted $commits | less -FRX
+fi


### PR DESCRIPTION
## Summary
- Show GPG signature status (G/N) with color coding in existing log commands (`lg`, `lgg`, `lgr`)
- Add new commands to filter commits by signature status: `lga`/`lgap` (signed), `lgu`/`lgup` (unsigned)
- Add `lgsign` interactive tool to retroactively sign unsigned commits via rebase
- Fix README.md formatting

## Test plan
- [x] Run `lg`, `lgg`, `lgr` and verify GPG status indicator appears
- [x] Run `lgu` to list unsigned commits
- [x] Run `lga` to list signed commits
- [x] Run `lgsign` to interactively sign unsigned commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)